### PR TITLE
Fixes #75

### DIFF
--- a/src/main/scala/gov/nasa/jpl/imce/oml/converters/internal/OMLText2Resolver.scala
+++ b/src/main/scala/gov/nasa/jpl/imce/oml/converters/internal/OMLText2Resolver.scala
@@ -2419,7 +2419,7 @@ object OMLText2Resolver {
       val tuples
       : Iterable[(TerminologyNestingAxiom, api.TerminologyGraph, api.TerminologyBox, api.ConceptKind)]
       = o2r
-        .queue_elements
+        .queue_edges
         .collect { case (_, x: TerminologyNestingAxiom) => x }
         .flatMap { x =>
           ( s.lookupTerminologyGraph(x.nestedTerminology),


### PR DESCRIPTION
The TerminologyNestingAxioms were effectively not converted because
they were scanned from the wrong collection. It is unfortunate the
type system didn't detect that the partial function always evaluated to false.